### PR TITLE
Matrix multiplication is associative but not commutative

### DIFF
--- a/CoordinateTransformations.ipynb
+++ b/CoordinateTransformations.ipynb
@@ -876,7 +876,7 @@
     "against:\n",
     "\n",
     "1.  Performing transformations out of order, or swapping the arguments\n",
-    "    of a matrix product (products are not associative).\n",
+    "    of a matrix product (products are not commutative).\n",
     "\n",
     "2.  Propagating transposes or inverses into a matrix product without\n",
     "    swapping the order of arguments.\n",


### PR DESCRIPTION
Small change, I think this is supposed to say commutative instead of associative.