### PR TITLE
fix formatting for equations

### DIFF
--- a/3DRotations.ipynb
+++ b/3DRotations.ipynb
@@ -171,12 +171,12 @@
     "id": "s8a7ZQV-st91"
    },
    "source": [
-    "\\begin{equation*}\n",
+    "$$\\begin{equation*}\n",
     "diff(\\theta_2,\\theta_1) = \\left\\lbrace \\begin{array}{ll} \\theta_2 - \\theta_1  & \\text{if } -\\pi < \\theta_2 - \\theta_1 \\leq \\pi \\\\\n",
     "\\theta_2 - \\theta_1 - 2\\pi & \\text{if } \\theta_2 - \\theta_1 > \\pi \\\\\n",
     "\\theta_2 - \\theta_1 + 2\\pi & \\text{if } \\theta_2 - \\theta_1 \\leq -\\pi\n",
     "\\end{array} \\right.\n",
-    "\\end{equation*}"
+    "\\end{equation*}$$"
    ]
   },
   {
@@ -645,7 +645,7 @@
     "e.g., for roll-pitch-yaw convention:\n",
     "\n",
     "\n",
-    "R_{rpy} =  \\begin{bmatrix}\n",
+    "$$R_{rpy} =  \\begin{bmatrix}\n",
     "r_{11} & r_{12} & r_{13} \\\\\n",
     "r_{21} & r_{22} & r_{23} \\\\\n",
     "r_{31} & r_{32} & r_{33} \n",
@@ -653,7 +653,7 @@
     "c_1 c_2  & c_1 s_2 s_3 - s_1 c_3 & s_1 s_3 + c_1 s_2 c_3 \\\\\n",
     "s_1 c_2  & c_1 c_3 + s_1 s_2 s_3 &  s_1 s_2 c_3 - c_1 s_3 \\\\\n",
     "- s_2    & c_2 s_3               & c_2 c_3  \n",
-    "\\end{bmatrix}\n",
+    "\\end{bmatrix}$$\n",
     "\n",
     "\n",
     "where we use the shorthand $c_1 = \\cos \\phi$,\n",
@@ -1031,7 +1031,7 @@
     "Note that these multiplication rules are non-symmetric. The product of\n",
     "two quaternions is a non-symmetric operation that is defined by applying\n",
     "standard distributive laws and the above rules:\n",
-    "\\begin{equation}\n",
+    "$$\\begin{equation}\n",
     "\\begin{split}\n",
     "q p  = & (q_0 + i q_1 + j q_2 + k q_3) (p_0 + i p_1 + j p_2 + k p_3) \\\\\n",
     " = & q_0 (p_0 + i p_1 + j p_2 + k p_3) + i q_1 (p_0 + i p_1 + j p_2 + k p_3) + \\\\\n",
@@ -1042,7 +1042,7 @@
     "   & j (q_0 p_2 + q_2 p_0 - q_1 p_3 + q_3 p_1) + k (q_0 p_3 + q_3 p_0 + q_1 p_2 -  q_2 p_1)\n",
     "\\end{split}\n",
     "\\label{eq:QuaternionMultiplication}\n",
-    "\\end{equation}\n",
+    "\\end{equation}\n$$",
     "Norms are defined as usual so that\n",
     "$|q| = \\sqrt{q_0^2 + q_1^2 + q_2^2 + q_3^2} = 1$ defines a unit\n",
     "quaternion. Unit quaternions have the special property that their\n",


### PR DESCRIPTION
fix formatting for equations when rendered in html (I can only test this in a notebook, where these equations were already rendered properly. notebook rendering seems to be more forgiving than the html version)